### PR TITLE
Fix for no module named v3 in novaclient anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## Unreleased
+### Fixed
+ - no module named v3 in novaclient
 
 ## [0.0.4] - 2015-09-29
 ### Changed

--- a/bin/nova/nova-hypervisor-metrics.py
+++ b/bin/nova/nova-hypervisor-metrics.py
@@ -11,8 +11,9 @@ from os import getenv
 import socket
 import time
 
-from novaclient.v3 import Client
+from novaclient.client import Client
 
+NOVA_API_VERSION = '2'
 DEFAULT_SCHEME = '{}.nova.hypervisors'.format(socket.gethostname())
 
 METRIC_KEYS = (
@@ -41,7 +42,7 @@ def main():
     parser.add_argument('-s', '--scheme', default=DEFAULT_SCHEME)
     args = parser.parse_args()
 
-    client = Client(args.user, args.password, args.tenant, args.auth_url, service_type=args.service_type)
+    client = Client(NOVA_API_VERSION, args.user, args.password, args.tenant, args.auth_url, service_type=args.service_type)
 
     if args.host:
         hypervisors = client.hypervisors.search(args.host)

--- a/bin/nova/nova-server-state-metrics.py
+++ b/bin/nova/nova-server-state-metrics.py
@@ -6,8 +6,9 @@ from os import getenv
 import socket
 import time
 
-from novaclient.v3 import Client
+from novaclient.client import Client
 
+NOVA_API_VERSION = '2'
 DEFAULT_SCHEME = '{}.nova.states'.format(socket.gethostname())
 
 def output_metric(name, value):
@@ -23,7 +24,7 @@ def main():
     parser.add_argument('-s', '--scheme', default=DEFAULT_SCHEME)
     args = parser.parse_args()
 
-    client = Client(args.user, args.password, args.tenant, args.auth_url, service_type=args.service_type)
+    client = Client(NOVA_API_VERSION, args.user, args.password, args.tenant, args.auth_url, service_type=args.service_type)
 
     servers = client.servers.list()
 


### PR DESCRIPTION
The novaclient Python module has removed the v3 submodule and instead require an API version number as the first argument to Client(). Nova plugin scripts updated accordingly.

Ref. novaclient docs: http://docs.openstack.org/developer/python-novaclient/api.html

This is to resolve the following error when using the Nova scripts:
$ ./bin/nova/nova-hypervisor-metrics.py
Traceback (most recent call last):
  File "./nova/nova-hypervisor-metrics.py", line 14, in <module>
    from novaclient.v3 import Client
ImportError: No module named v3
