### PR TITLE
Report Nova hypervisor metrics aggregated for all hypervisors

### DIFF
--- a/bin/nova/nova-hypervisor-metrics.py
+++ b/bin/nova/nova-hypervisor-metrics.py
@@ -54,5 +54,10 @@ def main():
             if key in METRIC_KEYS:
                 output_metric('{}.{}.{}'.format(args.scheme, hv.hypervisor_hostname, key), value)
 
+    if not args.host:
+        for key, value in client.hypervisor_stats.statistics().to_dict().iteritems():
+            output_metric('{}.{}.{}'.format(args.scheme, 'total', key), value)
+
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Nova has aggregate metrics for all hypervisors, which is easier to report directly than to try to aggregate in the metric store, at least when using InfluxDB instead of Graphite/Carbon.

The aggregate metrics are only reported if the host argument is not set. When using a host filter the aggregate values are probably not what people want in the output, but in all other cases they should be interesting.

Note that I omitted the METRIC_KEYS filter for the aggregate metrics, primarily to get "count" reported too (the total number of hypervisors, which is interesting in itself).
